### PR TITLE
Improve dev ops flow

### DIFF
--- a/.github/workflows/production-release.yaml
+++ b/.github/workflows/production-release.yaml
@@ -1,0 +1,23 @@
+name: PRODUCTION release
+
+on: workflow_dispatch
+
+jobs:
+  push-production-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Login to ghcr'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GHCR_PUSH_TOKEN}}
+
+      - name: 'Build and push'
+        run: |
+          docker image tag ghcr.io/catchsudheera/brs-backend:rc ghcr.io/catchsudheera/brs-backend:production
+          docker push ghcr.io/catchsudheera/brs-backend:production
+          docker image tag ghcr.io/catchsudheera/brs-frontend:rc ghcr.io/catchsudheera/brs-frontend:production
+          docker push ghcr.io/catchsudheera/brs-frontend:production
+          
+          

--- a/.github/workflows/publish-backend-image-ghcr.yaml
+++ b/.github/workflows/publish-backend-image-ghcr.yaml
@@ -1,6 +1,6 @@
-name: BACKEND Build and publish images to ghcr
+name: BACKEND Staging build
 
-on: workflow_dispatch
+on: [push, workflow_dispatch]
 
 jobs:
   push-backend-image:
@@ -9,8 +9,11 @@ jobs:
       run:
         working-directory: './backend'
     steps:
-      - name: 'Checkout latest main branch'
-        uses: actions/checkout@main
+      - name: 'Checkout the branch that triggered the workflow'
+        uses: actions/checkout@v4
+
+      - name: 'Set the tag name according to the branch'
+        run: if [ "${GITHUB_REF##*/}" = "main" ]; then echo "TAG=rc" >> $GITHUB_ENV; else echo "TAG=staging" >> $GITHUB_ENV; fi
 
       - name: 'Packaging environment'
         uses: actions/setup-java@v3
@@ -30,6 +33,6 @@ jobs:
 
       - name: 'Build and push'
         run: |
-          docker build . --tag ghcr.io/catchsudheera/brs-backend:v1.2
-          docker push ghcr.io/catchsudheera/brs-backend:v1.2
+          docker build . --tag ghcr.io/catchsudheera/brs-backend:$TAG
+          docker push ghcr.io/catchsudheera/brs-backend:$TAG
 

--- a/.github/workflows/publish-backend-image-ghcr.yaml
+++ b/.github/workflows/publish-backend-image-ghcr.yaml
@@ -1,6 +1,9 @@
 name: BACKEND Staging build
 
-on: [push, workflow_dispatch]
+on:
+  push:
+    paths:
+      - backend/**
 
 jobs:
   push-backend-image:

--- a/.github/workflows/publish-frontend-image-ghcr.yaml
+++ b/.github/workflows/publish-frontend-image-ghcr.yaml
@@ -1,6 +1,9 @@
 name: FRONTEND Staging build
 
-on: [push, workflow_dispatch]
+on:
+  push:
+    paths:
+      - frontend/**
 
 jobs:
   push-backend-image:

--- a/.github/workflows/publish-frontend-image-ghcr.yaml
+++ b/.github/workflows/publish-frontend-image-ghcr.yaml
@@ -1,6 +1,6 @@
-name: FRONTEND Build and publish images to ghcr
+name: FRONTEND Staging build
 
-on: workflow_dispatch
+on: [push, workflow_dispatch]
 
 jobs:
   push-backend-image:
@@ -9,8 +9,11 @@ jobs:
       run:
         working-directory: './frontend'
     steps:
-      - name: 'Checkout latest main branch'
-        uses: actions/checkout@main
+      - name: 'Checkout the branch that triggered the workflow'
+        uses: actions/checkout@v4
+
+      - name: 'Set the tag name according to the branch'
+        run: if [ "${GITHUB_REF##*/}" = "main" ]; then echo "TAG=rc" >> $GITHUB_ENV; else echo "TAG=staging" >> $GITHUB_ENV; fi
 
       - name: 'Login to ghcr'
         uses: docker/login-action@v1
@@ -21,6 +24,6 @@ jobs:
 
       - name: 'Build and push'
         run: |
-          docker build . --tag ghcr.io/catchsudheera/brs-frontend:v1.2
-          docker push ghcr.io/catchsudheera/brs-frontend:v1.2
+          docker build . --tag ghcr.io/catchsudheera/brs-frontend:$TAG
+          docker push ghcr.io/catchsudheera/brs-frontend:$TAG
 

--- a/deployment/ansible-playbook/inventories/default/group_vars/all.yml
+++ b/deployment/ansible-playbook/inventories/default/group_vars/all.yml
@@ -6,11 +6,12 @@ gv_server_timezone: Europe/Amsterdam
 ansible_user: ubuntu
 gv_local_brs_user: brs-user
 gv_local_brs_uid: 1007
-gv_local_brs_group: home-guardian-server
+gv_local_brs_group: brs_group
 gv_local_brs_gid: 1007
 gv_local_brs_user_home: "/home/{{ gv_local_brs_user }}"
 
 gv_docker_network_name: brs-server-network
+gv_docker_compose_reload_systemd_on_calendar_cron: hourly
 
 # Storage location type. Options : [local, nfs]
 gv_storage_location_type: local

--- a/deployment/ansible-playbook/roles/container-stack-brs/tasks/main.yml
+++ b/deployment/ansible-playbook/roles/container-stack-brs/tasks/main.yml
@@ -38,6 +38,7 @@
   vars:
     docker_compose_dir_path: "{{ brs_container_stack_location }}"
     stack_name: container-stack-brs
+    docker_compose_reload_systemd_on_calendar_cron: "{{ brs_docker_compose_reload_systemd_on_calendar_cron }}"
 
 - name: Stop Docker containers if running
   block:

--- a/deployment/ansible-playbook/roles/container-stack-brs/vars/main.yml
+++ b/deployment/ansible-playbook/roles/container-stack-brs/vars/main.yml
@@ -9,6 +9,7 @@ container_data_root: "{{ gv_container_data_root }}"
 brs_container_stack_location: "{{ gv_local_brs_user_home }}/.container-stack-brs"
 
 docker_network_name: "{{ gv_docker_network_name }}"
+brs_docker_compose_reload_systemd_on_calendar_cron: "{{ gv_docker_compose_reload_systemd_on_calendar_cron }}"
 
 # Mysql
 mysql_config_path: "{{ container_data_root }}/mysql/config"

--- a/deployment/ansible-playbook/roles/docker-compose-systemd/templates/docker-compose-reload.timer.j2
+++ b/deployment/ansible-playbook/roles/docker-compose-systemd/templates/docker-compose-reload.timer.j2
@@ -1,10 +1,9 @@
 [Unit]
 Description=Refresh images and update containers for {{ docker_compose_dir_path }}
-Requires={{ docker_compose_service_unit_file_name }}
 After={{ docker_compose_service_unit_file_name }}
 
 [Timer]
-OnCalendar=hourly
+OnCalendar={{ docker_compose_reload_systemd_on_calendar_cron }}
 
 [Install]
 WantedBy=timers.target

--- a/deployment/ansible-playbook/roles/docker-compose-systemd/templates/docker-compose.service.j2
+++ b/deployment/ansible-playbook/roles/docker-compose-systemd/templates/docker-compose.service.j2
@@ -15,6 +15,7 @@ ExecStop=/usr/bin/docker-compose down --remove-orphans --timeout 100
 
 ExecReload=/usr/bin/docker-compose pull --ignore-pull-failures --include-deps
 ExecReload=/usr/bin/docker-compose up -d --always-recreate-deps
+ExecReload=/usr/bin/docker image prune -f
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
[github workflows]
 - Added a separate production build trigger
 - staging image build on push
 - Limit trigger to be/fe dirs
 
[systemd]
 - Added dangling image prune.
 - Removed hard dependency on service from the timer
 - Externalized timer cron

