### PR TITLE
Fixing the broken graph by pre-filling the missing data

### DIFF
--- a/frontend/src/contexts/RankingHistoryContext.tsx
+++ b/frontend/src/contexts/RankingHistoryContext.tsx
@@ -58,7 +58,7 @@ export const RankingHistoryProvider: React.FC<{ children: ReactNode }> = ({
 
     // Iterating through the data set to prefill ranks where missing.
     //  1. Virtual staring date gets the oldRank of the player on the first date.
-    //  2. Players started in the middle get the old rank assigned from the virtual staring date until the encounter date before they first joined.
+    //  2. Players started in the middle get the initial old rank assigned for the encouter date before the one they first joined.
 
     const playerToInitialOldRankMap = historyPerPlayerArr.map((playerHistory) => {
       const sortedHistory = playerHistory.history.sort(
@@ -69,13 +69,19 @@ export const RankingHistoryProvider: React.FC<{ children: ReactNode }> = ({
     });
 
     ranksPerDateArr.unshift({date: format(startingDate, 'yyyy-MM-dd')});
-    ranksPerDateArr.forEach((e) => {
+    let playedAdded: string[] = [];
+    ranksPerDateArr.reverse().forEach((e) => {
       for (let item of playerToInitialOldRankMap) {
-         if(!(item.player in e)) {
-            e[item.player] = item.initialOldRank;
-         }
+        if (!(playedAdded.includes(item.player)) && !(item.player in e)) {
+          e[item.player] = item.initialOldRank;
+          playedAdded.push(item.player);
+        } else if(!(item.player in e)) {
+          e[item.player] = null;
+        }
       }
     });
+
+    ranksPerDateArr.reverse();
 
     return ranksPerDateArr;
   };

--- a/frontend/src/types/playerHistoryTypes.ts
+++ b/frontend/src/types/playerHistoryTypes.ts
@@ -12,7 +12,7 @@ export interface PlayerHistory {
 
 export interface GraphData {
   date: string;
-  [key: string]: string | number;
+  [key: string]: string | number | null;
 }
 
 export interface RankingHistoryContextType {


### PR DESCRIPTION
Approach : 

1. All players have a virtual initial date plotted in the graph where it is a date 7 days before the very first encounter
2. Players joined in the middle gets pre-filled from the encounter date before they first joined

Graph looks like this

![Screenshot from 2024-04-08 10-27-05](https://github.com/catchsudheera/brs/assets/1343216/8f10a461-5d63-4aa4-8170-78c84e9ecd40)
