### PR TITLE
Order absentee streak query newest-first

### DIFF
--- a/backend/src/main/java/com/brs/backend/core/CommonAbsenteeManager.java
+++ b/backend/src/main/java/com/brs/backend/core/CommonAbsenteeManager.java
@@ -31,7 +31,7 @@ public class CommonAbsenteeManager {
         var absentees = new HashMap<Player, Integer>();
         var longTermAbsentees = new ArrayList<Player>();
         for (Player player : players) {
-            var games = scoreHistoryRepository.findAllByPlayerId(player.getId());
+            var games = scoreHistoryRepository.findAllByPlayerIdOrderByEncounterDateDescIdDesc(player.getId());
             var inactiveGamesBefore = countAbsentTimes(games);
 
             if (inactiveGamesBefore >= 5) {

--- a/backend/src/main/java/com/brs/backend/repositories/ScoreHistoryRepository.java
+++ b/backend/src/main/java/com/brs/backend/repositories/ScoreHistoryRepository.java
@@ -11,6 +11,11 @@ public interface ScoreHistoryRepository extends JpaRepository<ScoreHistory, Inte
 
     List<ScoreHistory> findAllByPlayerId(Integer id);
 
+    // Ordered newest-first so callers that take a recent window (e.g. the absentee
+    // streak in CommonAbsenteeManager) genuinely get the most recent rows. Plain
+    // findAllByPlayerId has no defined order, so a positional limit on it is unreliable.
+    List<ScoreHistory> findAllByPlayerIdOrderByEncounterDateDescIdDesc(Integer playerId);
+
     List<ScoreHistory> findAllByPlayerIdAndEncounterDate(Integer playerId, LocalDate encounterDate);
 
     Optional<ScoreHistory> findFirstByPlayerIdOrderByEncounterDateDesc(Integer playerId);


### PR DESCRIPTION
countAbsentTimes() takes the 5 most recent score-history rows via Stream.limit(5), but it was fed by findAllByPlayerId, which has no defined order (rows arrive in DB/insertion order, typically oldest first). The "last 5" window could therefore reflect a player's oldest rows, mis-driving both the escalating absentee penalty and the deactivation threshold.

Add findAllByPlayerIdOrderByEncounterDateDescIdDesc and use it for the absentee window so the recent-5 window is genuinely the most recent 5.